### PR TITLE
Allow the user to pass their own session

### DIFF
--- a/src/pyfreedompro/functions.py
+++ b/src/pyfreedompro/functions.py
@@ -4,72 +4,59 @@ import async_timeout
 
 FREEDOMPRO_URL = "https://api.freedompro.eu/api/freedompro/accessories"
 
-async def get_list(apikey):
+async def get_list(apikey, httpsession):
     headers = {
         "Authorization": f"Bearer {apikey}",
         "Content-Type": "application/json",
     }
     try:
-        httpsession = aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))
         with async_timeout.timeout(10000):
-            resp = await httpsession.get(FREEDOMPRO_URL, headers=headers)
+            resp = await httpsession.get(FREEDOMPRO_URL, headers=headers, ssl=False)
             status = resp.status
 
             if status == 200:
                 devices = await resp.json()
-                await httpsession.close()
                 return {"state": True, "devices": devices}
 
             if status == 401:
-                await httpsession.close()
                 return {"state": False, "code": -201}
 
-            await httpsession.close()
             return {"state": False, "code": -200}
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        await httpsession.close()
         return {"state": False, "code": -200}
 
-async def get_states(apikey):
+async def get_states(apikey, httpsession):
     headers = {
         "Authorization": f"Bearer {apikey}",
         "Content-Type": "application/json",
     }
     try:
-        httpsession = aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))
         with async_timeout.timeout(10000):
-            resp = await httpsession.get(f"{FREEDOMPRO_URL}/state", headers=headers)
+            resp = await httpsession.get(f"{FREEDOMPRO_URL}/state", headers=headers, ssl=False)
             status = resp.status
             if status == 200:
                 data = await resp.json()
-                await httpsession.close()
                 return data
-            await httpsession.close()
             return []
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        await httpsession.close()
         return []
 
 
-async def put_state(apikey, uid, payload):
+async def put_state(apikey, uid, payload, httpsession):
     headers = {
         "Authorization": f"Bearer {apikey}",
         "Content-Type": "application/json",
     }
     try:
-        httpsession = aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))
         with async_timeout.timeout(10000):
             resp = await httpsession.put(
-                f"{FREEDOMPRO_URL}/{uid}/state", data=payload, headers=headers
+                f"{FREEDOMPRO_URL}/{uid}/state", data=payload, headers=headers, ssl=False
             )
             status = resp.status
             if status == 200:
                 data = await resp.json()
                 if "state" in data:
-                    await httpsession.close()
                     return data["state"]
-            await httpsession.close()
             return {}
     except (asyncio.TimeoutError, aiohttp.ClientError):
-        await httpsession.close()
         return {}


### PR DESCRIPTION
See issue #1.
This allows the user to pass his own aiohttp.ClientSession﻿ instead of creating one for every library call.﻿
Also removes `httpsession.close()`, this should be done by the library user.
